### PR TITLE
Brush up buildout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@
 
 all: .installed.cfg
 
-bin/pip:
-	python3 -m venv . || virtualenv -p python3 --no-site-packages --no-setuptools . || virtualenv -p python3 --no-setuptools .
+py3/bin/pip:
+	python3 -m venv py3 || virtualenv -p python3 --no-site-packages --no-setuptools py3 || virtualenv -p python3 --no-setuptools py3
 
-bin/buildout: bin/pip requirements.txt
-	./bin/pip install -IUr requirements.txt
+py3/bin/buildout: py3/bin/pip requirements.txt
+	./py3/bin/pip install -IUr requirements.txt
 
-.installed.cfg: bin/buildout *.cfg
-	./bin/buildout
+.installed.cfg: py3/bin/buildout *.cfg
+	./py3/bin/buildout
 
 upgrade:
 	./bin/upgrade plone_upgrade -S &&  ./bin/upgrade install -Sp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: all upgrade restart
+
+all: .installed.cfg
+
+bin/pip:
+	python3 -m venv . || virtualenv -p python3 --no-site-packages --no-setuptools . || virtualenv -p python3 --no-setuptools .
+
+bin/buildout: bin/pip requirements.txt
+	./bin/pip install -IUr requirements.txt
+
+.installed.cfg: bin/buildout *.cfg
+	./bin/buildout
+
+upgrade:
+	./bin/upgrade plone_upgrade -S &&  ./bin/upgrade install -Sp
+
+restart:
+	./bin/supervisord || ( ./bin/supervisorctl reread && ./bin/supervisorctl restart all)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--r https://dist.plone.org/release/5.2.5/requirements.txt
+-r https://dist.plone.org/release/5.2.7/requirements.txt


### PR DESCRIPTION
Added Makefile. Also aligned requirements.txt with versions.cfg.

On my local machine, `make` always runs `pip install` and `buildout`. I would expect it to only run when `.installed.cfg` or a dependency are out of date. I noticed that manually touching files makes a difference:

```
oira@oira:~/oira.application.buildout (master +)
[10:19:32]$ make bin/buildout
./bin/pip install -IUr requirements.txt
[...]
^CERROR: Operation cancelled by user
[...]
make: *** [Makefile:9: bin/buildout] Error 1

oira@oira:~/oira.application.buildout (master +)
[10:19:49]$ make bin/pip
make: 'bin/pip' is up to date.
oira@oira:~/oira.application.buildout (master +)
[10:19:56]$ touch bin/buildout
oira@oira:~/oira.application.buildout (master +)
[10:20:23]$ make bin/buildout
make: 'bin/buildout' is up to date.
```

@ale-rt, @pysailor, do you have any idea why that is?

Refs [SCR-1768](https://jira.syslab.com/browse/SCR-1768)