### PR TITLE
Remove a deprecation warning

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -13,8 +13,8 @@ allow-picked-versions = false
 develop =
 
 [settings]
-postgres-url = postgres://XXXX:XXXX@localhost/euphorie
-postgres-url-statistics = postgres://XXXX:XXXX@localhost/{database}
+postgres-url = postgresql://XXXX:XXXX@localhost/euphorie
+postgres-url-statistics = postgresql://XXXX:XXXX@localhost/{database}
 smartprintng-url = http://127.0.0.1:6543
 http-address = 8080
 zeo-address = 8020

--- a/dev-ale.cfg
+++ b/dev-ale.cfg
@@ -15,7 +15,7 @@ auto-checkout -=
     plone.app.locales
 
 [settings]
-postgres-url = postgres://XXX:XXX@localhost:5432/XXXXXX
+postgres-url = postgresql://XXX:XXX@localhost:5432/XXXXXX
 http-address = 8380
 zeo-address = 8389
 

--- a/dev-pilz.cfg
+++ b/dev-pilz.cfg
@@ -14,7 +14,7 @@ auto-checkout -=
     plone.app.locales
 
 [settings]
-postgres-url = postgres://euphorie2:euphorie2@localhost:5432/euphorie2
+postgres-url = postgresql://euphorie2:euphorie2@localhost:5432/euphorie2
 http-address = 8380
 zeo-address = 8389
 

--- a/dev-pysailor.cfg
+++ b/dev-pysailor.cfg
@@ -5,7 +5,7 @@ extends =
 allow-picked-versions = false
 
 [settings]
-postgres-url = postgres://XXXX:XXXX@ubuntung/euphorie5
+postgres-url = postgresql://XXXX:XXXX@ubuntung/euphorie5
 http-address = 13280
 zeo-address = 3420
 

--- a/production.cfg
+++ b/production.cfg
@@ -3,7 +3,7 @@ extends = base.cfg
 
 [settings]
 smartprintng-url = http://osha-oira-py3-prod-backend.mainstrat.com:6543
-postgres-url = postgres://euphorie2:secret@osha-oira-py3-prod-backend.mainstrat.com/euphorie2
+postgres-url = postgresql://euphorie2:secret@osha-oira-py3-prod-backend.mainstrat.com/euphorie2
 zeo-address = osha-oira-py3-prod-backend.mainstrat.com:8020
 
 

--- a/staging-py3.cfg
+++ b/staging-py3.cfg
@@ -11,7 +11,7 @@ allow-picked-versions = false
 
 
 [settings]
-postgres-url = postgres://XXXX:XXXX@ubuntung/euphorie5
+postgres-url = postgresql://XXXX:XXXX@ubuntung/euphorie5
 http-address = 8080
 zeo-address = 8020
 

--- a/staging.cfg
+++ b/staging.cfg
@@ -11,7 +11,7 @@ osha.oira = git https://github.com/euphorie/osha.oira.git
 
 
 [settings]
-postgres-url = postgres://XXXX:XXXX@ubuntung/euphorie5
+postgres-url = postgresql://XXXX:XXXX@ubuntung/euphorie5
 http-address = 8080
 zeo-address = 8020
 


### PR DESCRIPTION
SADeprecationWarning: The 'postgres' dialect name has been renamed to 'postgresql'