### PR TITLE
Added sentry

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -44,6 +44,7 @@ eggs+=
     Products.MemcachedManager
     Products.PloneHotfix20200121==1.0
     Products.PloneHotfix20210518==1.2
+    sentry_sdk
 eggs -=
     Products.PDBDebugMode
 zcml =
@@ -73,6 +74,12 @@ zope-conf-additional +=
     <product-config osha.oira>
         postgres-url-statistics ${settings:postgres-url-statistics}
     </product-config>
+
+sentry_dsn =
+sentry_ignore = slowlog
+initialization =
+    import sentry_sdk
+    sentry_sdk.utils.MAX_STRING_LENGTH = 4096
 
 [euphorie.ini]
 recipe = collective.recipe.template

--- a/picked_versions.cfg
+++ b/picked_versions.cfg
@@ -10,6 +10,7 @@ psycopg2 = 2.9.1
 pyasn1 = 0.4.8
 pyasn1-modules = 0.2.8
 python-ldap = 3.3.1
+sentry-sdk = 0.14.1
 superlance = 1.0.0
 yafowil = 2.3.3
 yafowil.plone = 4.0.0a3

--- a/production.cfg
+++ b/production.cfg
@@ -18,3 +18,5 @@ zcml-additional =
        <db:engine name="session" url="${settings:postgres-url}" echo="false" />
        <db:session engine="session" />
    </configure>
+environment-vars +=
+    SENTRY_ENVIRONMENT production

--- a/staging-py3.cfg
+++ b/staging-py3.cfg
@@ -27,4 +27,6 @@ zcml-additional =
        <db:engine name="session" url="${settings:postgres-url}" echo="false" />
        <db:session engine="session" />
    </configure>
+environment-vars +=
+    SENTRY_ENVIRONMENT staging
 

--- a/staging.cfg
+++ b/staging.cfg
@@ -27,4 +27,6 @@ zcml-additional =
        <db:engine name="session" url="${settings:postgres-url}" echo="false" />
        <db:session engine="session" />
    </configure>
+environment-vars +=
+    SENTRY_ENVIRONMENT staging
 


### PR DESCRIPTION
This adds Sentry setup but leaves the DSN empty. For a single buildout it's easy to add. However, on staging and production we have multiple machines that all need the DSN set. We have to decide whether to check the DSN in to version control (we do that in star) or keep it secret. In the latter case, if we don't want to manage the DSN manually on every VM, we need to set up some means of deploying encrypted secrets, like the ansible vault or something similar to [oira.statistics.deployment secrets](https://github.com/EU-OSHA/oira.statistics.deployment/blob/master/Makefile#L14).

Refs syslabcom/scrum#262