### PR TITLE
Workaround for genshi error

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -118,7 +118,7 @@ input = ${buildout:directory}/templates/${:_buildout_section_name_}
 output = ${buildout:directory}/etc/${:_buildout_section_name_}
 
 [alembic-statistics.ini]
-recipe = collective.recipe.template[genshi]:genshi
+recipe = collective.recipe.genshi
 input = ${buildout:directory}/templates/${:_buildout_section_name_}
 output = ${buildout:directory}/etc/${:_buildout_section_name_}
 


### PR DESCRIPTION
Workaround for ModuleNotFoundError: No module named 'genshi'