### PR TITLE
Revert "Upgrade Plone to 5.2.11"

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://raw.githubusercontent.com/euphorie/Euphorie/14.3.2/buildout.cfg
+    https://raw.githubusercontent.com/euphorie/Euphorie/14.3.1/buildout.cfg
     picked_versions.cfg
 parts +=
     supervisor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--r https://dist.plone.org/release/5.2.11/requirements.txt
+-r https://dist.plone.org/release/5.2.10/requirements.txt


### PR DESCRIPTION
This reverts commit ebfe2a70217f33a3eb8a4a8d5d077bf1b9e7c323.

We want to stick to Plone 5.2.10 for the moment
