### PR TITLE
Remove alembic for the statistics DBs

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -6,7 +6,6 @@ parts +=
     supervisor
     oirascripts
     alembic.ini
-    alembic-statistics.ini
     upgrade
 find-links +=
     https://spypi.syslab.com/packages/
@@ -108,11 +107,6 @@ programs =
 
 [alembic.ini]
 recipe = collective.recipe.template
-input = ${buildout:directory}/templates/${:_buildout_section_name_}
-output = ${buildout:directory}/etc/${:_buildout_section_name_}
-
-[alembic-statistics.ini]
-recipe = collective.recipe.genshi
 input = ${buildout:directory}/templates/${:_buildout_section_name_}
 output = ${buildout:directory}/etc/${:_buildout_section_name_}
 


### PR DESCRIPTION
Moved to oira.statistics.deployment
https://github.com/EU-OSHA/oira.statistics.deployment/commit/9c83543ec3dbc9878175be404560a119b117d568

Ref syslabcom/scrum#2348